### PR TITLE
bump regex to 1.3, fix a warning.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,5 @@ path = "src/bin/main.rs"
 doc = false
 
 [dependencies]
-regex = "0.2"
+regex = "1.3"
 lazy_static = "1"

--- a/src/lib/french.rs
+++ b/src/lib/french.rs
@@ -253,7 +253,7 @@ impl FrenchFormatter {
                 let next = chars[i + 1];
 
                 match current {
-                    '0'...'9' => {
+                    '0'..='9' => {
                         if i == 0 || !chars[i - 1].is_alphabetic() {
                             is_number_series = true;
                         }


### PR DESCRIPTION
This bumps, regex to a newer version, which drops about a minute of compile time halves the binary size, of my program, from duplicate versions of regex/unicode tables I imagine.

The testsuite passed, and I looked through the regex change history a bit, and nothing jumped out at me that might affect the regular expressions used here.  I'm not sure if you want to be bothered with chasing latest releases and what not -- If not I can figure something out.

While doing that, I also fixed this warning.

```
warning: `...` range patterns are deprecated
...
256 |                     '0'...'9' => {
    |                        ^^^ help: use `..=` for an inclusive range
```